### PR TITLE
Add implementation of `diff_from_delta`.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ root = true
 charset = utf-8
 end_of_line = LF
 indent_size = 4
-indent_style = tab
+indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/src/chars.rs
+++ b/src/chars.rs
@@ -1,4 +1,4 @@
-use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
+use percent_encoding::{percent_decode, utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use std::{
     borrow::Borrow,
     fmt, mem,
@@ -45,6 +45,14 @@ impl Chars {
 
     pub fn take(&mut self) -> Self {
         Chars(mem::take(&mut self.0))
+    }
+
+    pub fn to_safe_decode(&self) -> Result<Self, ()> {
+        let tmp: &[u8] = &self[..].iter().map(|c| *c as u8).collect::<Vec<_>>();
+        match percent_decode(tmp).decode_utf8() {
+            Err(_) => Err(()),
+            Ok(s) => Ok(Chars::from(s.to_string())),
+        }
     }
 
     pub fn to_safe_encode(&self) -> String {

--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -775,6 +775,39 @@ fn diff_to_delta() {
 }
 
 #[test]
+fn diff_from_delta() {
+    let dmp = DiffMatchPatch::new();
+    let text1 = Chars::from("jumps over the lazy");
+    let delta = "=4\t-1\t+ed\t=6\t-3\t+a\t=5\t+old dog";
+    let diffs_computed = dmp.diff_from_delta(&text1, delta);
+    let diffs_expected = vec![
+        Equal("jump".into()),
+        Delete("s".into()),
+        Insert("ed".into()),
+        Equal(" over ".into()),
+        Delete("the".into()),
+        Insert("a".into()),
+        Equal(" lazy".into()),
+        Insert("old dog".into()),
+    ];
+    assert_eq!(Ok(diffs_expected), diffs_computed);
+}
+
+#[test]
+fn diff_from_delta_special_characters() {
+    let dmp = DiffMatchPatch::new();
+    let text1 = Chars::from("\u{0680} \x00 \t %\u{0681} \x01 \n ^");
+    let delta = "=7\t-7\t+%DA%82 %02 %5C %7C";
+    let diffs_computed = dmp.diff_from_delta(&text1, delta);
+    let diffs_expected = vec![
+        Equal("\u{0680} \x00 \t %".into()),
+        Delete("\u{0681} \x01 \n ^".into()),
+        Insert("\u{0682} \x02 \\ |".into()),
+    ];
+    assert_eq!(Ok(diffs_expected), diffs_computed);
+}
+
+#[test]
 fn diff_xindex() {
     // Translate a location in text1 to text2.
 

--- a/tests/patch.rs
+++ b/tests/patch.rs
@@ -17,8 +17,8 @@ fn patch_obj() {
 
     */
     let p = Patch {
-        start1: Some(20),
-        start2: Some(21),
+        start1: 20,
+        start2: 21,
         length1: 18,
         length2: 17,
         diffs: vec![


### PR DESCRIPTION
# Implementation of `diff_from_delta`

## Problem description

See related issue #1 

It is currently possible to build a single string containing all the `Diff`s. But it is not possible to get them back from the `Delta`.

## Solution

The function `diff_from_delta` has been implemented based on [Python version](https://github.com/google/diff-match-patch/blob/master/python3/diff_match_patch.py#L1160).